### PR TITLE
fix: 限制 bonus 命令仅管理员可执行

### DIFF
--- a/src/main/java/org/mods/gd656killicon/server/command/ServerCommands.java
+++ b/src/main/java/org/mods/gd656killicon/server/command/ServerCommands.java
@@ -37,7 +37,7 @@ public class ServerCommands {
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(
             Commands.literal("gd656killicon").then(Commands.literal("server")
-                .then(Commands.literal("bonus")
+                .then(Commands.literal("bonus").requires(s -> s.hasPermission(2))
                     .then(Commands.literal("turnon")
                         .then(Commands.literal("all").executes(c -> toggleBonus(c, true, true)))
                         .then(Commands.argument("type", StringArgumentType.word())


### PR DESCRIPTION
## 修复内容

为 `/gd656killicon server bonus` 命令分支补充 `requires(s -> s.hasPermission(2))` 权限校验。

## 背景

`server bonus` 分支 (`turnon` / `turnoff` / `edit expression`) 之前没有任何权限校验, 而同一命令下的 `reset` / `config` / `statistics`(写操作) / `honor` / `debug` 分支均已有 `hasPermission(2)`。由于 Brigadier 中未设置 `requires` 的命令默认对所有玩家开放, 普通玩家(权限等级 0)可以:

- `turnon all` / `turnoff all` — 全服启用/关闭所有加分项
- `edit <type> expression <expr>` — 篡改任意加分项倍率表达式, 改动会通过 `saveConfig()` 持久化到服务器配置, 导致全服玩家得分异常

## 改动

`ServerCommands.java` 一行:

```java
- .then(Commands.literal(bonus)
+ .then(Commands.literal(bonus).requires(s -> s.hasPermission(2))
```

修复后该分支与同命令下其他管理员命令一致, 只有 op(权限等级 >= 2)可以执行, 普通玩家功能不受影响。

## Summary by Sourcery

Bug Fixes:
- 在 `server bonus` 命令中添加权限检查，防止非管理员玩家切换或编辑全局奖励设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add a permission check to the `server bonus` command to prevent non-admin players from toggling or editing global bonus settings.

</details>